### PR TITLE
Implement (hacky) batch rendering & more

### DIFF
--- a/CNCMaps.Renderer.GUI/MainForm.Designer.cs
+++ b/CNCMaps.Renderer.GUI/MainForm.Designer.cs
@@ -99,6 +99,7 @@ namespace CNCMaps.GUI {
             this.lblFill = new System.Windows.Forms.ToolStripStatusLabel();
             this.pbProgress = new System.Windows.Forms.ToolStripProgressBar();
             this.toolTip = new System.Windows.Forms.ToolTip(this.components);
+            this.label6 = new System.Windows.Forms.Label();
             this.tabControl = new System.Windows.Forms.TabControl();
             this.tpMain = new System.Windows.Forms.TabPage();
             this.lblCommand = new System.Windows.Forms.Label();
@@ -109,6 +110,13 @@ namespace CNCMaps.GUI {
             this.rtbLog = new System.Windows.Forms.RichTextBox();
             this.tpAbout = new System.Windows.Forms.TabPage();
             this.label1 = new System.Windows.Forms.Label();
+            this.tpBatch = new System.Windows.Forms.TabPage();
+            this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.btnClearList = new System.Windows.Forms.Button();
+            this.label2 = new System.Windows.Forms.Label();
+            this.tbBatchInput = new System.Windows.Forms.TextBox();
+            this.btnBrowseMaps = new System.Windows.Forms.Button();
+            this.button1 = new System.Windows.Forms.Button();
             this.gbMiscOptions.SuspendLayout();
             this.gbOreGems.SuspendLayout();
             this.gbStartMarkers.SuspendLayout();
@@ -130,6 +138,8 @@ namespace CNCMaps.GUI {
             this.tpLog.SuspendLayout();
             this.gbLog.SuspendLayout();
             this.tpAbout.SuspendLayout();
+            this.tpBatch.SuspendLayout();
+            this.groupBox1.SuspendLayout();
             this.SuspendLayout();
             // 
             // gbMiscOptions
@@ -218,7 +228,7 @@ namespace CNCMaps.GUI {
             // lblStartMarkerType
             // 
             this.lblStartMarkerType.AutoSize = true;
-            this.lblStartMarkerType.Location = new System.Drawing.Point(352, 14);
+            this.lblStartMarkerType.Location = new System.Drawing.Point(338, 14);
             this.lblStartMarkerType.Name = "lblStartMarkerType";
             this.lblStartMarkerType.Size = new System.Drawing.Size(72, 13);
             this.lblStartMarkerType.TabIndex = 35;
@@ -250,9 +260,9 @@ namespace CNCMaps.GUI {
             "Diamond",
             "Ellipsed",
             "Tiled"});
-            this.cmbStartMarkers.Location = new System.Drawing.Point(354, 28);
+            this.cmbStartMarkers.Location = new System.Drawing.Point(341, 28);
             this.cmbStartMarkers.Name = "cmbStartMarkers";
-            this.cmbStartMarkers.Size = new System.Drawing.Size(86, 21);
+            this.cmbStartMarkers.Size = new System.Drawing.Size(99, 21);
             this.cmbStartMarkers.TabIndex = 8;
             this.cmbStartMarkers.Text = "Diamond";
             this.cmbStartMarkers.SelectedIndexChanged += new System.EventHandler(this.cmbStartMarkers_SelectedIndexChanged);
@@ -521,18 +531,18 @@ namespace CNCMaps.GUI {
             this.gbModConfig.Controls.Add(this.btnModEditor);
             this.gbModConfig.Controls.Add(this.tbModConfig);
             this.gbModConfig.Controls.Add(this.cbModConfig);
-            this.gbModConfig.Location = new System.Drawing.Point(6, 217);
+            this.gbModConfig.Location = new System.Drawing.Point(8, 217);
             this.gbModConfig.Name = "gbModConfig";
-            this.gbModConfig.Size = new System.Drawing.Size(569, 42);
+            this.gbModConfig.Size = new System.Drawing.Size(567, 42);
             this.gbModConfig.TabIndex = 44;
             this.gbModConfig.TabStop = false;
             // 
             // btnModEditor
             // 
             this.btnModEditor.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnModEditor.Location = new System.Drawing.Point(489, 11);
+            this.btnModEditor.Location = new System.Drawing.Point(487, 13);
             this.btnModEditor.Name = "btnModEditor";
-            this.btnModEditor.Size = new System.Drawing.Size(75, 23);
+            this.btnModEditor.Size = new System.Drawing.Size(75, 20);
             this.btnModEditor.TabIndex = 28;
             this.btnModEditor.Text = "Open editor";
             this.btnModEditor.UseVisualStyleBackColor = true;
@@ -545,7 +555,7 @@ namespace CNCMaps.GUI {
             | System.Windows.Forms.AnchorStyles.Right)));
             this.tbModConfig.Location = new System.Drawing.Point(154, 13);
             this.tbModConfig.Name = "tbModConfig";
-            this.tbModConfig.Size = new System.Drawing.Size(329, 20);
+            this.tbModConfig.Size = new System.Drawing.Size(327, 20);
             this.tbModConfig.TabIndex = 24;
             this.tbModConfig.Visible = false;
             this.tbModConfig.TextChanged += new System.EventHandler(this.UIChanged);
@@ -569,9 +579,9 @@ namespace CNCMaps.GUI {
             this.gbFilename.Controls.Add(this.tbCustomOutput);
             this.gbFilename.Controls.Add(this.rbCustomFilename);
             this.gbFilename.Controls.Add(this.rbAutoFilename);
-            this.gbFilename.Location = new System.Drawing.Point(6, 130);
+            this.gbFilename.Location = new System.Drawing.Point(8, 130);
             this.gbFilename.Name = "gbFilename";
-            this.gbFilename.Size = new System.Drawing.Size(569, 36);
+            this.gbFilename.Size = new System.Drawing.Size(567, 36);
             this.gbFilename.TabIndex = 43;
             this.gbFilename.TabStop = false;
             // 
@@ -595,7 +605,7 @@ namespace CNCMaps.GUI {
             | System.Windows.Forms.AnchorStyles.Right)));
             this.tbCustomOutput.Location = new System.Drawing.Point(334, 11);
             this.tbCustomOutput.Name = "tbCustomOutput";
-            this.tbCustomOutput.Size = new System.Drawing.Size(220, 20);
+            this.tbCustomOutput.Size = new System.Drawing.Size(228, 20);
             this.tbCustomOutput.TabIndex = 17;
             this.tbCustomOutput.Visible = false;
             this.tbCustomOutput.TextChanged += new System.EventHandler(this.UIChanged);
@@ -788,16 +798,16 @@ namespace CNCMaps.GUI {
             this.pnlEngine.Controls.Add(this.rbEngineRA2);
             this.pnlEngine.Controls.Add(this.rbEngineYR);
             this.pnlEngine.Controls.Add(this.lbEngine);
-            this.pnlEngine.Location = new System.Drawing.Point(3, 173);
+            this.pnlEngine.Location = new System.Drawing.Point(8, 172);
             this.pnlEngine.Name = "pnlEngine";
-            this.pnlEngine.Size = new System.Drawing.Size(527, 42);
+            this.pnlEngine.Size = new System.Drawing.Size(567, 43);
             this.pnlEngine.TabIndex = 41;
             // 
             // rbEngineFS
             // 
             this.rbEngineFS.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.rbEngineFS.AutoSize = true;
-            this.rbEngineFS.Location = new System.Drawing.Point(388, 20);
+            this.rbEngineFS.Location = new System.Drawing.Point(384, 22);
             this.rbEngineFS.Name = "rbEngineFS";
             this.rbEngineFS.Size = new System.Drawing.Size(68, 17);
             this.rbEngineFS.TabIndex = 24;
@@ -810,7 +820,7 @@ namespace CNCMaps.GUI {
             // 
             this.rbEngineTS.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.rbEngineTS.AutoSize = true;
-            this.rbEngineTS.Location = new System.Drawing.Point(294, 20);
+            this.rbEngineTS.Location = new System.Drawing.Point(290, 22);
             this.rbEngineTS.Name = "rbEngineTS";
             this.rbEngineTS.Size = new System.Drawing.Size(69, 17);
             this.rbEngineTS.TabIndex = 22;
@@ -824,7 +834,7 @@ namespace CNCMaps.GUI {
             this.rbEngineAuto.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.rbEngineAuto.AutoSize = true;
             this.rbEngineAuto.Checked = true;
-            this.rbEngineAuto.Location = new System.Drawing.Point(12, 20);
+            this.rbEngineAuto.Location = new System.Drawing.Point(8, 22);
             this.rbEngineAuto.Name = "rbEngineAuto";
             this.rbEngineAuto.Size = new System.Drawing.Size(82, 17);
             this.rbEngineAuto.TabIndex = 18;
@@ -838,7 +848,7 @@ namespace CNCMaps.GUI {
             // 
             this.rbEngineRA2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.rbEngineRA2.AutoSize = true;
-            this.rbEngineRA2.Location = new System.Drawing.Point(200, 20);
+            this.rbEngineRA2.Location = new System.Drawing.Point(196, 22);
             this.rbEngineRA2.Name = "rbEngineRA2";
             this.rbEngineRA2.Size = new System.Drawing.Size(76, 17);
             this.rbEngineRA2.TabIndex = 20;
@@ -851,7 +861,7 @@ namespace CNCMaps.GUI {
             // 
             this.rbEngineYR.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.rbEngineYR.AutoSize = true;
-            this.rbEngineYR.Location = new System.Drawing.Point(106, 20);
+            this.rbEngineYR.Location = new System.Drawing.Point(102, 22);
             this.rbEngineYR.Name = "rbEngineYR";
             this.rbEngineYR.Size = new System.Drawing.Size(70, 17);
             this.rbEngineYR.TabIndex = 19;
@@ -894,9 +904,9 @@ namespace CNCMaps.GUI {
             // btnBrowseMixDir
             // 
             this.btnBrowseMixDir.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnBrowseMixDir.Location = new System.Drawing.Point(500, 42);
+            this.btnBrowseMixDir.Location = new System.Drawing.Point(500, 44);
             this.btnBrowseMixDir.Name = "btnBrowseMixDir";
-            this.btnBrowseMixDir.Size = new System.Drawing.Size(75, 23);
+            this.btnBrowseMixDir.Size = new System.Drawing.Size(75, 20);
             this.btnBrowseMixDir.TabIndex = 5;
             this.btnBrowseMixDir.Text = "Browse";
             this.btnBrowseMixDir.UseVisualStyleBackColor = true;
@@ -926,9 +936,9 @@ namespace CNCMaps.GUI {
             // btnBrowseInput
             // 
             this.btnBrowseInput.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnBrowseInput.Location = new System.Drawing.Point(500, 16);
+            this.btnBrowseInput.Location = new System.Drawing.Point(500, 18);
             this.btnBrowseInput.Name = "btnBrowseInput";
-            this.btnBrowseInput.Size = new System.Drawing.Size(75, 23);
+            this.btnBrowseInput.Size = new System.Drawing.Size(75, 20);
             this.btnBrowseInput.TabIndex = 2;
             this.btnBrowseInput.Text = "Browse";
             this.btnBrowseInput.UseVisualStyleBackColor = true;
@@ -937,7 +947,7 @@ namespace CNCMaps.GUI {
             // btnRenderExecute
             // 
             this.btnRenderExecute.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnRenderExecute.Location = new System.Drawing.Point(506, 295);
+            this.btnRenderExecute.Location = new System.Drawing.Point(501, 281);
             this.btnRenderExecute.Name = "btnRenderExecute";
             this.btnRenderExecute.Size = new System.Drawing.Size(75, 23);
             this.btnRenderExecute.TabIndex = 32;
@@ -950,11 +960,11 @@ namespace CNCMaps.GUI {
             this.tbCommandPreview.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.tbCommandPreview.BackColor = System.Drawing.SystemColors.ControlLight;
-            this.tbCommandPreview.Location = new System.Drawing.Point(73, 277);
+            this.tbCommandPreview.Location = new System.Drawing.Point(73, 281);
             this.tbCommandPreview.Multiline = true;
             this.tbCommandPreview.Name = "tbCommandPreview";
             this.tbCommandPreview.ReadOnly = true;
-            this.tbCommandPreview.Size = new System.Drawing.Size(423, 58);
+            this.tbCommandPreview.Size = new System.Drawing.Size(423, 52);
             this.tbCommandPreview.TabIndex = 30;
             this.toolTip.SetToolTip(this.tbCommandPreview, "For more fine-grained control you can invoke CNCMaps.Renderer.exe manually!");
             // 
@@ -992,6 +1002,17 @@ namespace CNCMaps.GUI {
             this.pbProgress.Size = new System.Drawing.Size(100, 16);
             this.pbProgress.Style = System.Windows.Forms.ProgressBarStyle.Continuous;
             // 
+            // label6
+            // 
+            this.label6.AutoSize = true;
+            this.label6.Location = new System.Drawing.Point(10, 75);
+            this.label6.Name = "label6";
+            this.label6.Size = new System.Drawing.Size(43, 13);
+            this.label6.TabIndex = 0;
+            this.label6.Text = "Map list";
+            this.toolTip.SetToolTip(this.label6, "Full paths the to input maps.\r\nValid filetypes are *.mpr, *.map, *.yrm, *.mmx, *." +
+        "yro.");
+            // 
             // tabControl
             // 
             this.tabControl.AllowDrop = true;
@@ -1000,6 +1021,7 @@ namespace CNCMaps.GUI {
             | System.Windows.Forms.AnchorStyles.Right)));
             this.tabControl.Controls.Add(this.tpMain);
             this.tabControl.Controls.Add(this.tpMisc);
+            this.tabControl.Controls.Add(this.tpBatch);
             this.tabControl.Controls.Add(this.tpLog);
             this.tabControl.Controls.Add(this.tpAbout);
             this.tabControl.Location = new System.Drawing.Point(3, 4);
@@ -1026,7 +1048,7 @@ namespace CNCMaps.GUI {
             // 
             // lblCommand
             // 
-            this.lblCommand.Location = new System.Drawing.Point(13, 297);
+            this.lblCommand.Location = new System.Drawing.Point(13, 281);
             this.lblCommand.Name = "lblCommand";
             this.lblCommand.Size = new System.Drawing.Size(54, 21);
             this.lblCommand.TabIndex = 0;
@@ -1114,6 +1136,86 @@ namespace CNCMaps.GUI {
             this.label1.Text = "Program by Frank Razenberg © 2005-2016\r\n\r\nSpecial thanks to Olaf van der Spek for" +
     " XCC.\r\nSpecial thanks to #renproj for modenc.";
             // 
+            // tpBatch
+            // 
+            this.tpBatch.Controls.Add(this.groupBox1);
+            this.tpBatch.Location = new System.Drawing.Point(4, 22);
+            this.tpBatch.Name = "tpBatch";
+            this.tpBatch.Padding = new System.Windows.Forms.Padding(3);
+            this.tpBatch.Size = new System.Drawing.Size(595, 339);
+            this.tpBatch.TabIndex = 4;
+            this.tpBatch.Text = "Batch render";
+            this.tpBatch.UseVisualStyleBackColor = true;
+            // 
+            // groupBox1
+            // 
+            this.groupBox1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.groupBox1.Controls.Add(this.button1);
+            this.groupBox1.Controls.Add(this.btnClearList);
+            this.groupBox1.Controls.Add(this.label2);
+            this.groupBox1.Controls.Add(this.tbBatchInput);
+            this.groupBox1.Controls.Add(this.label6);
+            this.groupBox1.Controls.Add(this.btnBrowseMaps);
+            this.groupBox1.Location = new System.Drawing.Point(6, 6);
+            this.groupBox1.Name = "groupBox1";
+            this.groupBox1.Size = new System.Drawing.Size(582, 327);
+            this.groupBox1.TabIndex = 1;
+            this.groupBox1.TabStop = false;
+            this.groupBox1.Text = "Batch map render";
+            // 
+            // btnClearList
+            // 
+            this.btnClearList.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnClearList.Location = new System.Drawing.Point(501, 71);
+            this.btnClearList.Name = "btnClearList";
+            this.btnClearList.Size = new System.Drawing.Size(75, 21);
+            this.btnClearList.TabIndex = 4;
+            this.btnClearList.Text = "Clear list";
+            this.btnClearList.UseVisualStyleBackColor = true;
+            this.btnClearList.Click += new System.EventHandler(this.BtnClearList_Click);
+            // 
+            // label2
+            // 
+            this.label2.Location = new System.Drawing.Point(10, 16);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(566, 48);
+            this.label2.TabIndex = 3;
+            this.label2.Text = resources.GetString("label2.Text");
+            // 
+            // tbBatchInput
+            // 
+            this.tbBatchInput.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.tbBatchInput.Location = new System.Drawing.Point(13, 98);
+            this.tbBatchInput.Multiline = true;
+            this.tbBatchInput.Name = "tbBatchInput";
+            this.tbBatchInput.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
+            this.tbBatchInput.Size = new System.Drawing.Size(563, 194);
+            this.tbBatchInput.TabIndex = 1;
+            // 
+            // btnBrowseMaps
+            // 
+            this.btnBrowseMaps.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnBrowseMaps.Location = new System.Drawing.Point(420, 71);
+            this.btnBrowseMaps.Name = "btnBrowseMaps";
+            this.btnBrowseMaps.Size = new System.Drawing.Size(75, 21);
+            this.btnBrowseMaps.TabIndex = 2;
+            this.btnBrowseMaps.Text = "Add maps";
+            this.btnBrowseMaps.UseVisualStyleBackColor = true;
+            this.btnBrowseMaps.Click += new System.EventHandler(this.BtnAddMaps_Click);
+            // 
+            // button1
+            // 
+            this.button1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.button1.Location = new System.Drawing.Point(420, 298);
+            this.button1.Name = "button1";
+            this.button1.Size = new System.Drawing.Size(156, 23);
+            this.button1.TabIndex = 33;
+            this.button1.Text = "Start batch rendering";
+            this.button1.UseVisualStyleBackColor = true;
+            this.button1.Click += new System.EventHandler(this.Button1_Click);
+            // 
             // MainForm
             // 
             this.AllowDrop = true;
@@ -1165,6 +1267,9 @@ namespace CNCMaps.GUI {
             this.gbLog.ResumeLayout(false);
             this.tpAbout.ResumeLayout(false);
             this.tpAbout.PerformLayout();
+            this.tpBatch.ResumeLayout(false);
+            this.groupBox1.ResumeLayout(false);
+            this.groupBox1.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -1254,6 +1359,14 @@ namespace CNCMaps.GUI {
         private Label lblSquaredStartPosDescription;
         private CheckBox cbStartMarkers;
         private GroupBox gbOreGems;
+        private TabPage tpBatch;
+        private GroupBox groupBox1;
+        private Label label2;
+        private TextBox tbBatchInput;
+        private Label label6;
+        private Button btnBrowseMaps;
+        private Button btnClearList;
+        private Button button1;
     }
 }
 

--- a/CNCMaps.Renderer.GUI/MainForm.Designer.cs
+++ b/CNCMaps.Renderer.GUI/MainForm.Designer.cs
@@ -104,19 +104,19 @@ namespace CNCMaps.GUI {
             this.tpMain = new System.Windows.Forms.TabPage();
             this.lblCommand = new System.Windows.Forms.Label();
             this.tpMisc = new System.Windows.Forms.TabPage();
+            this.tpBatch = new System.Windows.Forms.TabPage();
+            this.gbBatchRender = new System.Windows.Forms.GroupBox();
+            this.btnBatchRender = new System.Windows.Forms.Button();
+            this.btnClearList = new System.Windows.Forms.Button();
+            this.label2 = new System.Windows.Forms.Label();
+            this.tbBatchInput = new System.Windows.Forms.TextBox();
+            this.btnBrowseMaps = new System.Windows.Forms.Button();
             this.tpLog = new System.Windows.Forms.TabPage();
             this.btnClearLog = new System.Windows.Forms.Button();
             this.gbLog = new System.Windows.Forms.GroupBox();
             this.rtbLog = new System.Windows.Forms.RichTextBox();
             this.tpAbout = new System.Windows.Forms.TabPage();
             this.label1 = new System.Windows.Forms.Label();
-            this.tpBatch = new System.Windows.Forms.TabPage();
-            this.groupBox1 = new System.Windows.Forms.GroupBox();
-            this.btnClearList = new System.Windows.Forms.Button();
-            this.label2 = new System.Windows.Forms.Label();
-            this.tbBatchInput = new System.Windows.Forms.TextBox();
-            this.btnBrowseMaps = new System.Windows.Forms.Button();
-            this.button1 = new System.Windows.Forms.Button();
             this.gbMiscOptions.SuspendLayout();
             this.gbOreGems.SuspendLayout();
             this.gbStartMarkers.SuspendLayout();
@@ -135,11 +135,11 @@ namespace CNCMaps.GUI {
             this.tabControl.SuspendLayout();
             this.tpMain.SuspendLayout();
             this.tpMisc.SuspendLayout();
+            this.tpBatch.SuspendLayout();
+            this.gbBatchRender.SuspendLayout();
             this.tpLog.SuspendLayout();
             this.gbLog.SuspendLayout();
             this.tpAbout.SuspendLayout();
-            this.tpBatch.SuspendLayout();
-            this.groupBox1.SuspendLayout();
             this.SuspendLayout();
             // 
             // gbMiscOptions
@@ -1065,6 +1065,88 @@ namespace CNCMaps.GUI {
             this.tpMisc.Text = "Misc settings";
             this.tpMisc.UseVisualStyleBackColor = true;
             // 
+            // tpBatch
+            // 
+            this.tpBatch.Controls.Add(this.gbBatchRender);
+            this.tpBatch.Location = new System.Drawing.Point(4, 22);
+            this.tpBatch.Name = "tpBatch";
+            this.tpBatch.Padding = new System.Windows.Forms.Padding(3);
+            this.tpBatch.Size = new System.Drawing.Size(595, 339);
+            this.tpBatch.TabIndex = 4;
+            this.tpBatch.Text = "Batch render";
+            this.tpBatch.UseVisualStyleBackColor = true;
+            // 
+            // gbBatchRender
+            // 
+            this.gbBatchRender.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.gbBatchRender.Controls.Add(this.btnBatchRender);
+            this.gbBatchRender.Controls.Add(this.btnClearList);
+            this.gbBatchRender.Controls.Add(this.label2);
+            this.gbBatchRender.Controls.Add(this.tbBatchInput);
+            this.gbBatchRender.Controls.Add(this.label6);
+            this.gbBatchRender.Controls.Add(this.btnBrowseMaps);
+            this.gbBatchRender.Location = new System.Drawing.Point(6, 6);
+            this.gbBatchRender.Name = "gbBatchRender";
+            this.gbBatchRender.Size = new System.Drawing.Size(582, 327);
+            this.gbBatchRender.TabIndex = 1;
+            this.gbBatchRender.TabStop = false;
+            this.gbBatchRender.Text = "Batch map render";
+            this.gbBatchRender.DragDrop += new System.Windows.Forms.DragEventHandler(this.InputDragDrop);
+            this.gbBatchRender.DragEnter += new System.Windows.Forms.DragEventHandler(this.InputDragEnter);
+            // 
+            // btnBatchRender
+            // 
+            this.btnBatchRender.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnBatchRender.Location = new System.Drawing.Point(420, 298);
+            this.btnBatchRender.Name = "btnBatchRender";
+            this.btnBatchRender.Size = new System.Drawing.Size(156, 23);
+            this.btnBatchRender.TabIndex = 33;
+            this.btnBatchRender.Text = "Start batch rendering";
+            this.btnBatchRender.UseVisualStyleBackColor = true;
+            this.btnBatchRender.Click += new System.EventHandler(this.BtnBatchRender_Click);
+            // 
+            // btnClearList
+            // 
+            this.btnClearList.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnClearList.Location = new System.Drawing.Point(501, 71);
+            this.btnClearList.Name = "btnClearList";
+            this.btnClearList.Size = new System.Drawing.Size(75, 21);
+            this.btnClearList.TabIndex = 4;
+            this.btnClearList.Text = "Clear list";
+            this.btnClearList.UseVisualStyleBackColor = true;
+            this.btnClearList.Click += new System.EventHandler(this.BtnClearList_Click);
+            // 
+            // label2
+            // 
+            this.label2.Location = new System.Drawing.Point(10, 16);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(566, 48);
+            this.label2.TabIndex = 3;
+            this.label2.Text = resources.GetString("label2.Text");
+            // 
+            // tbBatchInput
+            // 
+            this.tbBatchInput.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.tbBatchInput.Location = new System.Drawing.Point(13, 98);
+            this.tbBatchInput.Multiline = true;
+            this.tbBatchInput.Name = "tbBatchInput";
+            this.tbBatchInput.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
+            this.tbBatchInput.Size = new System.Drawing.Size(563, 194);
+            this.tbBatchInput.TabIndex = 1;
+            // 
+            // btnBrowseMaps
+            // 
+            this.btnBrowseMaps.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnBrowseMaps.Location = new System.Drawing.Point(420, 71);
+            this.btnBrowseMaps.Name = "btnBrowseMaps";
+            this.btnBrowseMaps.Size = new System.Drawing.Size(75, 21);
+            this.btnBrowseMaps.TabIndex = 2;
+            this.btnBrowseMaps.Text = "Add maps";
+            this.btnBrowseMaps.UseVisualStyleBackColor = true;
+            this.btnBrowseMaps.Click += new System.EventHandler(this.BtnAddMaps_Click);
+            // 
             // tpLog
             // 
             this.tpLog.Controls.Add(this.btnClearLog);
@@ -1136,86 +1218,6 @@ namespace CNCMaps.GUI {
             this.label1.Text = "Program by Frank Razenberg © 2005-2016\r\n\r\nSpecial thanks to Olaf van der Spek for" +
     " XCC.\r\nSpecial thanks to #renproj for modenc.";
             // 
-            // tpBatch
-            // 
-            this.tpBatch.Controls.Add(this.groupBox1);
-            this.tpBatch.Location = new System.Drawing.Point(4, 22);
-            this.tpBatch.Name = "tpBatch";
-            this.tpBatch.Padding = new System.Windows.Forms.Padding(3);
-            this.tpBatch.Size = new System.Drawing.Size(595, 339);
-            this.tpBatch.TabIndex = 4;
-            this.tpBatch.Text = "Batch render";
-            this.tpBatch.UseVisualStyleBackColor = true;
-            // 
-            // groupBox1
-            // 
-            this.groupBox1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.groupBox1.Controls.Add(this.button1);
-            this.groupBox1.Controls.Add(this.btnClearList);
-            this.groupBox1.Controls.Add(this.label2);
-            this.groupBox1.Controls.Add(this.tbBatchInput);
-            this.groupBox1.Controls.Add(this.label6);
-            this.groupBox1.Controls.Add(this.btnBrowseMaps);
-            this.groupBox1.Location = new System.Drawing.Point(6, 6);
-            this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(582, 327);
-            this.groupBox1.TabIndex = 1;
-            this.groupBox1.TabStop = false;
-            this.groupBox1.Text = "Batch map render";
-            // 
-            // btnClearList
-            // 
-            this.btnClearList.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnClearList.Location = new System.Drawing.Point(501, 71);
-            this.btnClearList.Name = "btnClearList";
-            this.btnClearList.Size = new System.Drawing.Size(75, 21);
-            this.btnClearList.TabIndex = 4;
-            this.btnClearList.Text = "Clear list";
-            this.btnClearList.UseVisualStyleBackColor = true;
-            this.btnClearList.Click += new System.EventHandler(this.BtnClearList_Click);
-            // 
-            // label2
-            // 
-            this.label2.Location = new System.Drawing.Point(10, 16);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(566, 48);
-            this.label2.TabIndex = 3;
-            this.label2.Text = resources.GetString("label2.Text");
-            // 
-            // tbBatchInput
-            // 
-            this.tbBatchInput.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.tbBatchInput.Location = new System.Drawing.Point(13, 98);
-            this.tbBatchInput.Multiline = true;
-            this.tbBatchInput.Name = "tbBatchInput";
-            this.tbBatchInput.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-            this.tbBatchInput.Size = new System.Drawing.Size(563, 194);
-            this.tbBatchInput.TabIndex = 1;
-            // 
-            // btnBrowseMaps
-            // 
-            this.btnBrowseMaps.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnBrowseMaps.Location = new System.Drawing.Point(420, 71);
-            this.btnBrowseMaps.Name = "btnBrowseMaps";
-            this.btnBrowseMaps.Size = new System.Drawing.Size(75, 21);
-            this.btnBrowseMaps.TabIndex = 2;
-            this.btnBrowseMaps.Text = "Add maps";
-            this.btnBrowseMaps.UseVisualStyleBackColor = true;
-            this.btnBrowseMaps.Click += new System.EventHandler(this.BtnAddMaps_Click);
-            // 
-            // button1
-            // 
-            this.button1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.button1.Location = new System.Drawing.Point(420, 298);
-            this.button1.Name = "button1";
-            this.button1.Size = new System.Drawing.Size(156, 23);
-            this.button1.TabIndex = 33;
-            this.button1.Text = "Start batch rendering";
-            this.button1.UseVisualStyleBackColor = true;
-            this.button1.Click += new System.EventHandler(this.Button1_Click);
-            // 
             // MainForm
             // 
             this.AllowDrop = true;
@@ -1263,13 +1265,13 @@ namespace CNCMaps.GUI {
             this.tpMain.ResumeLayout(false);
             this.tpMain.PerformLayout();
             this.tpMisc.ResumeLayout(false);
+            this.tpBatch.ResumeLayout(false);
+            this.gbBatchRender.ResumeLayout(false);
+            this.gbBatchRender.PerformLayout();
             this.tpLog.ResumeLayout(false);
             this.gbLog.ResumeLayout(false);
             this.tpAbout.ResumeLayout(false);
             this.tpAbout.PerformLayout();
-            this.tpBatch.ResumeLayout(false);
-            this.groupBox1.ResumeLayout(false);
-            this.groupBox1.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -1360,13 +1362,13 @@ namespace CNCMaps.GUI {
         private CheckBox cbStartMarkers;
         private GroupBox gbOreGems;
         private TabPage tpBatch;
-        private GroupBox groupBox1;
+        private GroupBox gbBatchRender;
         private Label label2;
         private TextBox tbBatchInput;
         private Label label6;
         private Button btnBrowseMaps;
         private Button btnClearList;
-        private Button button1;
+        private Button btnBatchRender;
     }
 }
 

--- a/CNCMaps.Renderer.GUI/MainForm.cs
+++ b/CNCMaps.Renderer.GUI/MainForm.cs
@@ -387,10 +387,16 @@ namespace CNCMaps.GUI
         private void InputDragDrop(object sender, DragEventArgs e)
         {
             var files = (string[])e.Data.GetData(DataFormats.FileDrop);
-            if (files.Length > 0)
+            if (files.Length == 1 && tabControl.SelectedTab != tpBatch)
             {
                 tbInput.Text = files[0];
                 UpdateCommandline();
+                tabControl.SelectTab(tpMain);
+            }
+            else if (files.Length > 0)
+            {
+                tbBatchInput.Lines = new List<string>().Concat(tbBatchInput.Lines).Concat(files).ToArray();
+                tabControl.SelectTab(tpBatch);
             }
         }
 
@@ -955,8 +961,14 @@ namespace CNCMaps.GUI
             tbBatchInput.Clear();
         }
 
-        private void Button1_Click(object sender, EventArgs e)
+        private void BtnBatchRender_Click(object sender, EventArgs e)
         {
+            if (String.IsNullOrWhiteSpace(tbBatchInput.Text))
+            {
+                UpdateStatus("no files provided in batch", 100);
+                MessageBox.Show("Add at least one map file to render!");
+                return;
+            }
             string oldInputMap = tbInput.Text;
             foreach (string mapPath in tbBatchInput.Lines)
             {

--- a/CNCMaps.Renderer.GUI/MainForm.cs
+++ b/CNCMaps.Renderer.GUI/MainForm.cs
@@ -135,7 +135,9 @@ namespace CNCMaps.GUI
 			cbTunnelPaths.Checked = Settings.Default.tunnelpaths;
 			cbTunnelPosition.Checked = Settings.Default.tunnelpos;
 
-			if (!cbTunnelPaths.Checked)
+            tbBatchInput.Lines = Settings.Default.batchinput.Split('\n');
+
+            if (!cbTunnelPaths.Checked)
 				cbTunnelPosition.Enabled = false;
 
             UpdateCommandline();
@@ -191,7 +193,9 @@ namespace CNCMaps.GUI
 			Settings.Default.tunnelpaths = cbTunnelPaths.Checked;
 			Settings.Default.tunnelpos = cbTunnelPosition.Checked;
 
-			Settings.Default.windowlocation = this.Location.X + ", " +  this.Location.Y;
+            Settings.Default.batchinput = String.Join("\n", tbBatchInput.Lines);
+
+            Settings.Default.windowlocation = this.Location.X + ", " +  this.Location.Y;
 
             Settings.Default.Save();
         }
@@ -929,5 +933,41 @@ namespace CNCMaps.GUI
         }
 
         #endregion
+
+        private void BtnAddMaps_Click(object sender, EventArgs e)
+        {
+            ofd.CheckFileExists = true;
+            ofd.Multiselect = true;
+            ofd.Filter = "RA2/TS map files (*.map, *.mpr, *.mmx, *.yrm, *.yro)|*.mpr;*.map;*.mmx;*.yrm;*.yro|All files (*.*)|*";
+            //if (string.IsNullOrEmpty(ofd.InitialDirectory))
+            //    ofd.InitialDirectory = FindMixDir(rbEngineAuto.Checked || rbEngineRA2.Checked || rbEngineYR.Checked);
+
+            ofd.FileName = "";
+            if (ofd.ShowDialog() == DialogResult.OK)
+            {
+                tbBatchInput.Lines = new List<string>().Concat(tbBatchInput.Lines).Concat(ofd.FileNames).ToArray();
+                ofd.InitialDirectory = Path.GetDirectoryName(ofd.FileName);
+            }
+        }
+
+        private void BtnClearList_Click(object sender, EventArgs e)
+        {
+            tbBatchInput.Clear();
+        }
+
+        private void Button1_Click(object sender, EventArgs e)
+        {
+            string oldInputMap = tbInput.Text;
+            foreach (string mapPath in tbBatchInput.Lines)
+            {
+                
+                if (!String.IsNullOrWhiteSpace(mapPath))
+                {
+                    tbInput.Text = mapPath;
+                    ExecuteCommand(this, EventArgs.Empty);
+                }
+            }
+            tbInput.Text = oldInputMap;
+        }
     }
 }

--- a/CNCMaps.Renderer.GUI/MainForm.resx
+++ b/CNCMaps.Renderer.GUI/MainForm.resx
@@ -146,6 +146,9 @@ for the non-zero component.</value>
 aspect ratio is preserved while the width/height is maximized
 for the non-zero component.</value>
   </data>
+  <metadata name="toolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>365, 17</value>
+  </metadata>
   <data name="rbEngineAuto.ToolTip" xml:space="preserve">
     <value>Tries to automatically deduce whether your map is made for RA2/YR, but is often unsuccessful,
 since this information is not actually stored in the map.
@@ -159,6 +162,15 @@ This will never render the map as if it is a TS/FS map, if it is you need to man
   </metadata>
   <metadata name="statusStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>256, 17</value>
+  </metadata>
+  <metadata name="toolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>365, 17</value>
+  </metadata>
+  <data name="label2.Text" xml:space="preserve">
+    <value>Experimental batch map rendering feature to allow using the map renderer on big amounts of maps without scripting knowledge. First configure desired settings on "Main settings" and "Misc settings" tabs, then add needed maps in the field below and press "Start batch rendering".</value>
+  </data>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>39</value>
   </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">

--- a/CNCMaps.Renderer.GUI/MainForm.resx
+++ b/CNCMaps.Renderer.GUI/MainForm.resx
@@ -146,9 +146,6 @@ for the non-zero component.</value>
 aspect ratio is preserved while the width/height is maximized
 for the non-zero component.</value>
   </data>
-  <metadata name="toolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>365, 17</value>
-  </metadata>
   <data name="rbEngineAuto.ToolTip" xml:space="preserve">
     <value>Tries to automatically deduce whether your map is made for RA2/YR, but is often unsuccessful,
 since this information is not actually stored in the map.
@@ -163,11 +160,8 @@ This will never render the map as if it is a TS/FS map, if it is you need to man
   <metadata name="statusStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>256, 17</value>
   </metadata>
-  <metadata name="toolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>365, 17</value>
-  </metadata>
   <data name="label2.Text" xml:space="preserve">
-    <value>Experimental batch map rendering feature to allow using the map renderer on big amounts of maps without scripting knowledge. First configure desired settings on "Main settings" and "Misc settings" tabs, then add needed maps in the field below and press "Start batch rendering".</value>
+    <value>Batch map rendering feature to allow using the map renderer on big amounts of maps without scripting knowledge. First configure desired settings on "Main settings" and "Misc settings" tabs, then add needed maps in the field below and press "Start batch rendering".</value>
   </data>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>39</value>

--- a/CNCMaps.Renderer.GUI/Properties/Settings.Designer.cs
+++ b/CNCMaps.Renderer.GUI/Properties/Settings.Designer.cs
@@ -563,5 +563,20 @@ namespace CNCMaps.GUI.Properties {
                 this["startmarkersize"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string batchinput
+        {
+            get
+            {
+                return ((string)(this["batchinput"]));
+            }
+            set
+            {
+                this["batchinput"] = value;
+            }
+        }
     }
 }


### PR DESCRIPTION
Implemented a separate tab with a maplist (newline-separated) to allow batch rendering, which is done via "feeding" individual non-empty lines one-by-one to the tbInput field and firing rendering for each time this is done. After this process old value is returned back into the field.

Also includes tweaks that involve adjusting UI elements sizes to look better overall.